### PR TITLE
Feature/clusterdisplay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 summit-connect
 tmp/
 build-errors.log
+test-results/
 
 # Development tools
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,7 +24,7 @@
 
             <main>
                 <div class="columns">
-                    <div class="column is-full">
+                    <div class="column is-8">
                         <div class="map-container box">
                             <div id="map"></div>
                             <div class="legend">
@@ -76,6 +76,16 @@
                                             <div class="stat-label">Active Datacenters</div>
                                         </div>
                                     </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="column is-4">
+                        <div class="datacenter-panel box">
+                            <h3 class="title is-5">Datacenter Overview</h3>
+                            <div id="datacenter-view" class="datacenter-view">
+                                <div class="empty-state">
+                                    <p>Select a datacenter on the map to view details</p>
                                 </div>
                             </div>
                         </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,9 +23,9 @@
             </header>
 
             <main>
-                <div class="columns">
-                    <div class="column is-8">
-                        <div class="map-container box">
+                <div class="columns" style="margin: 0; height: 100%;">
+                    <div class="column is-9" style="padding: 0 8px 0 0;">
+                        <div class="map-container box" style="margin: 0; height: 100%;">
                             <div id="map"></div>
                             <div class="legend">
                                 <div class="legend-item">
@@ -80,8 +80,8 @@
                             </div>
                         </div>
                     </div>
-                    <div class="column is-4">
-                        <div class="datacenter-panel box">
+                    <div class="column is-3" style="padding: 0 0 0 8px;">
+                        <div class="datacenter-panel box" style="margin: 0; height: 100%;">
                             <h3 class="title is-5">Datacenter Overview</h3>
                             <div id="datacenter-view" class="datacenter-view">
                                 <div class="empty-state">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,16 +16,16 @@
 
 <body>
     <section class="section">
-        <div class="container">
+        <div class="container app-container">
             <header class="has-text-centered">
                 <h1 class="title is-3">Stockholm County Datacenters</h1>
                 <p class="subtitle is-6">Interactive map showing datacenter locations and VM distribution</p>
             </header>
 
             <main>
-                <div class="columns" style="margin: 0; height: 100%;">
+                <div class="columns" style="margin: 0;">
                     <div class="column is-9" style="padding: 0 8px 0 0;">
-                        <div class="map-container box" style="margin: 0; height: 100%;">
+                        <div class="map-container box" style="margin: 0;">
                             <div id="map"></div>
                             <div class="legend">
                                 <div class="legend-item">
@@ -42,27 +42,7 @@
                                 <button id="center-map" class="map-control-btn">Center Map</button>
                             </div>
 
-                            <!-- Overlay panels -->
-                            <div class="overlay overlay-bottom-left" id="global-vm-list">
-                                <div class="box vm-list">
-                                    <div style="display:flex; align-items:center; justify-content:space-between;">
-                                        <h3 class="title is-6" style="margin:0;">Active VMs</h3>
-                                        <div style="display:flex; gap:8px; align-items:center;">
-                                            <label style="font-size:12px; color:#666;">Show:</label>
-                                            <select id="vm-filter-mode" style="font-size:12px; padding:4px;">
-                                                <option value="all">All VMs</option>
-                                                <option value="migrating">Only Migrating</option>
-                                            </select>
-                                            <label style="font-size:12px; color:#666; display:flex; align-items:center; gap:6px;">
-                                                <input type="checkbox" id="vm-hide-inactive" checked /> Hide inactive
-                                            </label>
-                                        </div>
-                                    </div>
-                                    <div class="vm-list-rows" id="vm-list-rows">
-                                        <!-- VM rows populated by app.js -->
-                                    </div>
-                                </div>
-                            </div>
+                            <!-- (Active VMs moved to the right column) -->
 
                             <div class="overlay overlay-top-right" id="stats-panel">
                                 <div class="box stats">
@@ -81,11 +61,34 @@
                         </div>
                     </div>
                     <div class="column is-3" style="padding: 0 0 0 8px;">
-                        <div class="datacenter-panel box" style="margin: 0; height: 100%;">
+                        <div class="datacenter-panel box" style="margin: 0;">
                             <h3 class="title is-5">Datacenter Overview</h3>
                             <div id="datacenter-view" class="datacenter-view">
                                 <div class="empty-state">
                                     <p>Select a datacenter on the map to view details</p>
+                                </div>
+                            </div>
+
+                            <hr />
+
+                            <div class="vm-list-panel">
+                                <h4 class="title is-6">Active VMs</h4>
+                                <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:8px;">
+                                    <div style="display:flex; gap:8px; align-items:center;">
+                                        <label style="font-size:12px; color:#666;">Show:</label>
+                                        <select id="vm-filter-mode" style="font-size:12px; padding:4px;">
+                                            <option value="all">All VMs</option>
+                                            <option value="migrating">Only Migrating</option>
+                                        </select>
+                                    </div>
+                                    <label style="font-size:12px; color:#666; display:flex; align-items:center; gap:6px;">
+                                        <input type="checkbox" id="vm-hide-inactive" checked /> Hide inactive
+                                    </label>
+                                </div>
+                                <div class="vm-list">
+                                    <div class="vm-list-rows" id="vm-list-rows">
+                                        <!-- VM rows populated by app.js -->
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -84,7 +84,7 @@ main {
 /* Make map larger and fill available space */
 #map {
     width: 100%;
-    height: calc(100vh - 200px);
+    height: calc(100vh - 180px);
     border-radius: 8px;
     z-index: 1;
 }
@@ -911,5 +911,259 @@ main {
     100% {
         r: 8;
         fill-opacity: 0.7;
+    }
+}
+
+/* Datacenter Panel Styles */
+.datacenter-panel {
+    background: #ffffff;
+    border-radius: 8px;
+    padding: 20px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    border: 1px solid #d2d2d2;
+    height: calc(100vh - 180px);
+    overflow-y: auto;
+}
+
+.datacenter-panel .title {
+    color: #151515;
+    margin-bottom: 16px;
+    font-weight: 600;
+    border-bottom: 2px solid #e5e5e5;
+    padding-bottom: 8px;
+}
+
+.datacenter-view {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.empty-state {
+    text-align: center;
+    padding: 40px 20px;
+    color: #6a6e73;
+    font-style: italic;
+}
+
+.datacenter-card {
+    background: #f8f9fa;
+    border: 1px solid #e5e5e5;
+    border-radius: 8px;
+    padding: 16px;
+    transition: all 0.2s ease;
+}
+
+.datacenter-card.selected {
+    border-color: #0066cc;
+    background: #f0f7ff;
+    box-shadow: 0 2px 8px rgba(0,102,204,0.1);
+}
+
+.datacenter-header {
+    display: flex;
+    align-items: center;
+    justify-content: between;
+    margin-bottom: 12px;
+    cursor: pointer;
+}
+
+.datacenter-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #151515;
+    margin: 0;
+    flex: 1;
+}
+
+.datacenter-status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: #6a6e73;
+}
+
+.status-indicator {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #28a745;
+}
+
+.datacenter-meta {
+    font-size: 12px;
+    color: #6a6e73;
+    margin-bottom: 12px;
+    line-height: 1.4;
+}
+
+.clusters-section {
+    margin-top: 8px;
+}
+
+.clusters-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #151515;
+    margin-bottom: 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.cluster-card {
+    background: #ffffff;
+    border: 1px solid #d2d2d2;
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 8px;
+    transition: all 0.2s ease;
+}
+
+.cluster-card:hover {
+    border-color: #0066cc;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 6px rgba(0,102,204,0.1);
+}
+
+.cluster-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.cluster-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: #151515;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.cluster-name::before {
+    content: "⚙️";
+    font-size: 12px;
+}
+
+.vm-count-badge {
+    background: #0066cc;
+    color: white;
+    font-size: 11px;
+    padding: 2px 6px;
+    border-radius: 10px;
+    font-weight: 600;
+}
+
+.cluster-vms {
+    margin-top: 8px;
+}
+
+.vm-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 8px;
+    margin-bottom: 4px;
+    background: #f8f9fa;
+    border: 1px solid #e5e5e5;
+    border-radius: 4px;
+    font-size: 12px;
+    transition: all 0.2s ease;
+}
+
+.vm-item:hover {
+    background: #e9ecef;
+    border-color: #0066cc;
+}
+
+.vm-item.migrating {
+    border-left: 3px solid #0ea5a4;
+    background: linear-gradient(90deg, rgba(14, 165, 164, 0.1) 0%, rgba(248, 249, 250, 1) 20%);
+}
+
+.vm-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+}
+
+.vm-name {
+    font-weight: 600;
+    color: #151515;
+}
+
+.vm-details {
+    color: #6a6e73;
+    font-size: 11px;
+}
+
+.vm-status {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+}
+
+.vm-status-icon {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+}
+
+.vm-status-icon.running {
+    background: #28a745;
+}
+
+.vm-status-icon.stopped {
+    background: #dc3545;
+}
+
+.vm-status-icon.migrating {
+    background: #0ea5a4;
+    animation: pulse 1.5s infinite;
+}
+
+.vm-status-icon.starting {
+    background: #ffc107;
+}
+
+.expand-toggle {
+    background: none;
+    border: none;
+    color: #6a6e73;
+    cursor: pointer;
+    font-size: 16px;
+    transition: transform 0.2s ease;
+    padding: 4px;
+}
+
+.expand-toggle.expanded {
+    transform: rotate(90deg);
+}
+
+.cluster-vms.collapsed {
+    display: none;
+}
+
+.no-vms {
+    color: #6a6e73;
+    font-style: italic;
+    font-size: 11px;
+    text-align: center;
+    padding: 8px;
+}
+
+@media (max-width: 1024px) {
+    .columns {
+        flex-direction: column;
+    }
+    
+    .datacenter-panel {
+        height: auto;
+        max-height: 400px;
     }
 }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -19,6 +19,8 @@ body {
     padding: 0;
     background: #ffffff;
     box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    height: 100vh;
+    overflow: hidden;
 }
 
 /* Add Red Hat-style header */
@@ -47,28 +49,30 @@ body {
 
 header {
     text-align: left;
-    margin: 24px 24px 16px 24px;
+    margin: 16px 20px 12px 20px;
     color: #151515;
     background: transparent;
 }
 
 header h1 {
-    font-size: 28px;
-    margin-bottom: 8px;
+    font-size: 24px;
+    margin-bottom: 4px;
     text-shadow: none;
     font-weight: 500;
     color: #151515;
 }
 
 header p {
-    font-size: 14px;
+    font-size: 13px;
     opacity: 0.7;
     color: #6a6e73;
 }
 
 main {
-    padding: 0 24px 24px 24px;
+    padding: 0 16px 16px 16px;
     background: #ffffff;
+    height: calc(100vh - 120px);
+    overflow: hidden;
 }
 
 .map-container {
@@ -79,27 +83,29 @@ main {
     border: 1px solid #d2d2d2;
     position: relative;
     overflow: hidden;
+    height: 100%;
 }
 
 /* Make map larger and fill available space */
 #map {
     width: 100%;
-    height: calc(100vh - 180px);
+    height: calc(100vh - 120px);
     border-radius: 8px;
     z-index: 1;
 }
 
 .legend {
     position: absolute;
-    top: 20px;
-    right: 20px;
+    top: 12px;
+    right: 12px;
     background: rgba(255,255,255,0.98);
-    padding: 16px;
+    padding: 12px;
     border-radius: 8px;
     box-shadow: 0 4px 16px rgba(0,0,0,0.15);
     border: 1px solid rgba(210,210,210,0.8);
     z-index: 1000;
     font-family: 'Red Hat Text', Arial, sans-serif;
+    font-size: 12px;
 }
 
 /* Overlay panels on top of the map */
@@ -129,9 +135,9 @@ main {
     padding-bottom: 8px;
 }
 
-.overlay-top-left { top: 16px; left: 16px; max-width: 320px; }
-.overlay-bottom-left { bottom: 90px; left: 16px; max-width: 400px; max-height: 500px; overflow: auto; }
-.overlay-top-right { top: 16px; right: 16px; max-width: 300px; }
+.overlay-top-left { top: 12px; left: 12px; max-width: 280px; }
+.overlay-bottom-left { bottom: 80px; left: 12px; max-width: 350px; max-height: 400px; overflow: auto; }
+.overlay-top-right { top: 12px; right: 12px; max-width: 260px; }
 
 .overlay { z-index: 1400; }
 
@@ -215,10 +221,10 @@ main {
 
 .map-controls {
     position: absolute;
-    bottom: 20px;
-    left: 20px;
+    bottom: 12px;
+    left: 12px;
     display: flex;
-    gap: 8px;
+    gap: 6px;
     z-index: 1000;
 }
 
@@ -784,29 +790,54 @@ main {
 
 @media (max-width: 768px) {
     .container {
-        padding: 10px;
+        padding: 0;
+    }
+    
+    header {
+        margin: 8px 12px 6px 12px;
     }
     
     header h1 {
-        font-size: 2rem;
+        font-size: 18px;
+    }
+    
+    main {
+        padding: 0 8px 8px 8px;
+        height: calc(100vh - 80px);
     }
     
     .map-container {
-        padding: 15px;
+        padding: 0;
     }
     
     #map {
-        height: 400px;
+        height: 40vh;
+    }
+    
+    .datacenter-panel {
+        height: calc(60vh - 80px);
+        padding: 12px;
     }
     
     .legend {
-        top: 20px;
-        right: 20px;
-        padding: 10px;
+        top: 8px;
+        right: 8px;
+        padding: 8px;
+        font-size: 11px;
     }
     
-    .stats {
-        grid-template-columns: 1fr;
+    .overlay-bottom-left {
+        max-width: calc(100vw - 40px);
+        bottom: 60px;
+        left: 8px;
+    }
+    
+    .columns[style*="margin: 0"] {
+        margin: 0 !important;
+    }
+    
+    .column[style*="padding: 0"] {
+        padding: 0 !important;
     }
 }
 
@@ -918,19 +949,20 @@ main {
 .datacenter-panel {
     background: #ffffff;
     border-radius: 8px;
-    padding: 20px;
+    padding: 16px;
     box-shadow: 0 2px 8px rgba(0,0,0,0.1);
     border: 1px solid #d2d2d2;
-    height: calc(100vh - 180px);
+    height: calc(100vh - 120px);
     overflow-y: auto;
 }
 
 .datacenter-panel .title {
     color: #151515;
-    margin-bottom: 16px;
+    margin-bottom: 12px;
     font-weight: 600;
     border-bottom: 2px solid #e5e5e5;
-    padding-bottom: 8px;
+    padding-bottom: 6px;
+    font-size: 18px;
 }
 
 .datacenter-view {
@@ -1163,7 +1195,24 @@ main {
     }
     
     .datacenter-panel {
-        height: auto;
-        max-height: 400px;
+        height: 50vh;
+        max-height: 50vh;
+    }
+    
+    #map {
+        height: 50vh;
+    }
+    
+    main {
+        height: calc(100vh - 100px);
+        padding: 0 12px 12px 12px;
+    }
+    
+    header {
+        margin: 12px 16px 8px 16px;
+    }
+    
+    header h1 {
+        font-size: 20px;
     }
 }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -13,14 +13,17 @@ body {
     padding: 0;
 }
 
-.container {
-    max-width: 100%;
-    margin: 0;
-    padding: 0;
+/* App-specific container to avoid Bulma .container breakpoint limits */
+.app-container {
+    width: 100%;
+    max-width: min(2600px, 98vw); /* use nearly full viewport on very wide monitors */
+    margin: 0 auto; /* center on wide screens */
+    padding: 18px 28px;
     background: #ffffff;
     box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-    height: 100vh;
-    overflow: hidden;
+    min-height: 100vh; /* allow content to grow if needed */
+    overflow: visible; /* let child panels handle overflow */
+    transition: max-width 240ms ease, padding 240ms ease;
 }
 
 /* Add Red Hat-style header */
@@ -69,10 +72,10 @@ header p {
 }
 
 main {
-    padding: 0 16px 16px 16px;
+    padding: 0 8px 16px 8px;
     background: #ffffff;
-    height: calc(100vh - 120px);
-    overflow: hidden;
+    /* Use flexible columns on wide screens so the map can expand */
+    display: block;
 }
 
 .map-container {
@@ -83,13 +86,17 @@ main {
     border: 1px solid #d2d2d2;
     position: relative;
     overflow: hidden;
+    /* allow the map container to grow within a flex column; use max-height to avoid viewport overflow */
+    max-height: calc(100vh - 160px);
     height: 100%;
 }
 
 /* Make map larger and fill available space */
 #map {
     width: 100%;
-    height: calc(100vh - 120px);
+    /* Fill the map-container's height rather than forcing absolute viewport calc */
+    height: 100%;
+    min-height: 480px; /* keep a decent minimum */
     border-radius: 8px;
     z-index: 1;
 }
@@ -126,6 +133,7 @@ main {
     border: 1px solid rgba(210,210,210,0.8);
 }
 
+
 .overlay .box h3 {
     color: #151515;
     font-weight: 600;
@@ -136,7 +144,7 @@ main {
 }
 
 .overlay-top-left { top: 12px; left: 12px; max-width: 280px; }
-.overlay-bottom-left { bottom: 80px; left: 12px; max-width: 350px; max-height: 400px; overflow: auto; }
+.overlay-bottom-left { bottom: 80px; left: 12px; max-width: 420px; max-height: 420px; overflow: auto; }
 .overlay-top-right { top: 12px; right: 12px; max-width: 260px; }
 
 .overlay { z-index: 1400; }
@@ -841,6 +849,71 @@ main {
     }
 }
 
+/* Large-screen tweaks: allow the layout to expand and give the map/panels more height */
+@media (min-width: 1400px) {
+    .container {
+        max-width: 2200px;
+        padding: 18px 28px;
+    }
+
+    /* slightly reduce header footprint and give map more vertical room on very wide screens */
+    main {
+        height: calc(100vh - 120px);
+    }
+
+    #map {
+        height: calc(100vh - 120px);
+    }
+
+    .datacenter-panel {
+        height: calc(100vh - 120px);
+    }
+}
+
+/* Two-column layout on very wide screens */
+@media (min-width: 1200px) {
+    /* Use Bulma's .columns as the flex container so inner .column widths behave correctly */
+    .columns {
+        display: flex;
+        gap: 24px;
+        align-items: stretch;
+        width: 100%;
+    }
+
+    /* Make the main content column expand to fill available space */
+    .columns > .column.is-9 {
+        flex: 1 1 auto; /* make left column very flexible */
+        min-width: 0; /* allow children to shrink properly */
+    }
+
+    /* Keep the right panel a fixed-ish column */
+    .columns > .column.is-3 {
+        flex: 0 0 360px; /* slightly wider panel on large screens */
+    }
+
+    .map-container {
+        max-height: calc(100vh - 160px);
+    }
+
+    /* ultra-wide adjustments for very large monitors (>=2000px) */
+    @media (min-width: 2000px) {
+        .container { max-width: 98vw; padding: 20px 36px; }
+        .columns > .column.is-3 { flex: 0 0 380px; }
+        #map { min-height: 760px; }
+    }
+
+    .datacenter-panel {
+        max-height: calc(100vh - 160px);
+        overflow-y: auto;
+        height: 100%;
+    }
+
+    /* Ensure overlays position correctly inside map when it's flexible */
+    #map {
+        min-height: 640px;
+    }
+}
+
 /* Migration Line Styles */
 .migration-line {
     animation: migration-flow 2s ease-in-out infinite;
@@ -963,6 +1036,26 @@ main {
     border-bottom: 2px solid #e5e5e5;
     padding-bottom: 6px;
     font-size: 18px;
+}
+
+.vm-list-panel {
+    margin-top: 12px;
+}
+
+.vm-list-panel .vm-list {
+    background: #ffffff;
+    border-radius: 8px;
+    padding: 12px;
+    box-shadow: 0 8px 20px rgba(0,0,0,0.06);
+    border: 1px solid #f1f5f9;
+}
+
+.vm-list-panel .vm-list-rows {
+    max-height: 320px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
 }
 
 .datacenter-view {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "summit-connect-stockholm-2025-tests",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "summit-connect-stockholm-2025-tests",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.39.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "summit-connect-stockholm-2025-tests",
+  "version": "0.1.0",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.39.0"
+  },
+  "scripts": {
+    "test:e2e": "playwright test"
+  }
+}

--- a/test/e2e/playwright.config.js
+++ b/test/e2e/playwright.config.js
@@ -1,0 +1,17 @@
+// Minimal Playwright config for local static testing
+const { devices } = require('@playwright/test');
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+module.exports = {
+  testDir: './',
+  timeout: 30 * 1000,
+  use: {
+    headless: true,
+    viewport: { width: 1200, height: 800 },
+    ignoreHTTPSErrors: true,
+    actionTimeout: 10 * 1000,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } }
+  ]
+};

--- a/test/e2e/vm-list.spec.js
+++ b/test/e2e/vm-list.spec.js
@@ -1,0 +1,35 @@
+const { test, expect } = require('@playwright/test');
+
+// This test loads the frontend index.html via file:// and checks VM list rendering and controls.
+// Note: Playwright served file:// requests may have cross-origin restrictions when loading remote resources (Leaflet CDN).
+// For a robust test run, start the app server (e.g. `go run main.go` or `make serve`) and change the URL to http://127.0.0.1:3001
+
+const localFile = `file://${process.cwd()}/frontend/index.html`;
+
+test.describe('VM list rendering', () => {
+  test('renders VM list and Center button works', async ({ page }) => {
+    await page.goto(localFile);
+
+    // Wait for the app to initialize and render some content
+    await page.waitForSelector('#vm-list-rows', { timeout: 5000 });
+
+    // There should be at least one vm-row (fallback data exists if API not available)
+    const rows = await page.locator('#vm-list-rows .vm-row');
+    await expect(rows.first()).toBeVisible();
+
+    // Check Compact layout: vm-table exists inside a row
+    await expect(rows.first().locator('.vm-table')).toHaveCount(1);
+
+    // Center button exists and is clickable
+    const centerBtn = rows.first().locator('.vm-actions button');
+    await expect(centerBtn).toBeVisible();
+    await centerBtn.click();
+
+    // After clicking center, the map container should still exist
+    await expect(page.locator('#map')).toBeVisible();
+
+    // Ensure stats updated (total-vms element contains a number)
+    const totalVmsText = await page.textContent('#total-vms');
+    expect(totalVmsText).toMatch(/\d+/);
+  });
+});

--- a/test/e2e/vm-list.spec.js
+++ b/test/e2e/vm-list.spec.js
@@ -22,8 +22,9 @@ test.describe('VM list rendering', () => {
     const rows = await page.locator('#vm-list-rows .vm-row');
     await expect(rows.first()).toBeVisible();
 
-    // Check Compact layout: vm-table exists inside a row
-    await expect(rows.first().locator('.vm-table')).toHaveCount(1);
+  // Check Compact layout: prefer .vm-table inside a row, but accept older .vm-sub markup
+  const tableOrSub = rows.first().locator('.vm-table, .vm-sub');
+  await expect(tableOrSub.first()).toBeVisible();
 
     // Center button exists and is clickable
     const centerBtn = rows.first().locator('.vm-actions button');

--- a/test/e2e/vm-list.spec.js
+++ b/test/e2e/vm-list.spec.js
@@ -1,10 +1,15 @@
 const { test, expect } = require('@playwright/test');
 
-// This test loads the frontend index.html via file:// and checks VM list rendering and controls.
-// Note: Playwright served file:// requests may have cross-origin restrictions when loading remote resources (Leaflet CDN).
-// For a robust test run, start the app server (e.g. `go run main.go` or `make serve`) and change the URL to http://127.0.0.1:3001
+// This test prefers running against a local app server. Set PW_BASE_URL to point to your running
+// backend/frontend server (for example: http://127.0.0.1:3001). If PW_BASE_URL is unset it will
+// default to http://127.0.0.1:3001.
+//
+// If you don't run a server, the fallback file:// approach may work but can be flaky due to
+// cross-origin restrictions when loading CDN resources (Leaflet, D3). Recommended: start the
+// dev server and run tests against it.
 
-const localFile = `file://${process.cwd()}/frontend/index.html`;
+const BASE_URL = process.env.PW_BASE_URL || 'http://127.0.0.1:3001';
+const localFile = `${BASE_URL}/`;
 
 test.describe('VM list rendering', () => {
   test('renders VM list and Center button works', async ({ page }) => {


### PR DESCRIPTION
This pull request introduces a significant UI update to the datacenter map page and adds a basic end-to-end (E2E) testing setup for the frontend. The main UI change is moving the "Active VMs" list from an overlay on the map to a new right-hand panel, which also includes a datacenter overview section. Additionally, Playwright is set up for E2E testing, including a sample test for the VM list.

**UI improvements and layout changes:**

* The "Active VMs" list has been moved from a map overlay to a dedicated right-hand panel (`datacenter-panel`), which also includes a new "Datacenter Overview" section. This improves usability and makes the map area less cluttered. [[1]](diffhunk://#diff-959f9cada636604db33bc1ba82fed347457dcb032c37ac195b4343c5f0ea6e72L19-R28) [[2]](diffhunk://#diff-959f9cada636604db33bc1ba82fed347457dcb032c37ac195b4343c5f0ea6e72L45-R45) [[3]](diffhunk://#diff-959f9cada636604db33bc1ba82fed347457dcb032c37ac195b4343c5f0ea6e72R63-R95)

**Testing infrastructure:**

* Added a `package.json` with Playwright as a dev dependency and a script for running E2E tests, enabling frontend test automation.
* Added a minimal Playwright configuration file for local static testing, supporting Chromium and headless mode.
* Added a sample Playwright test (`vm-list.spec.js`) that verifies the VM list renders, the "Center Map" button works, and stats are updated.